### PR TITLE
No workflows shows without release, push, or pull_request

### DIFF
--- a/.github/workflows/flutter_release_all.yml
+++ b/.github/workflows/flutter_release_all.yml
@@ -1,6 +1,8 @@
 name: Flutter CI
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adding a release published event to display it in actions tab