### PR TITLE
Networking entitlements added for release

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
I verified running locally, devices are getting listed. @guyluz11 can you once test linux and windows build generated in latest release section if they works. 