### PR TITLE
Added build step to workflow

### DIFF
--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -59,3 +59,6 @@ jobs:
         run: flutter analyze
       - name: Run tests
         run: flutter test
+      - name: Build dev debug flavor
+        run: |
+          flutter build apk --debug --flavor dev

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,0 +1,2 @@
+Bug fixes and improvements
+network_tools updated to v3.2.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Network Analyzer
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.1+14
+version: 1.0.1+15
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
@@ -33,8 +33,8 @@ dependencies:
   isolate_contactor: ^2.0.0+1
   # Discover network info and configure themselves accordingly
   network_info_plus: ^3.0.1
-# Helps you discover open ports, devices on subnet and more.
-  network_tools: ^3.0.0+3
+  # Helps you discover open ports, devices on subnet and more.
+  network_tools: ^3.2.1
   # network_tools:
   #   path: ../network_tools/network_tools
   # Querying information about the application package, such as CFBundleVersion


### PR DESCRIPTION
Fdroid build was failing because network_tools version was old.
Added build step in workflow for PR build, so that fdroid and gha builds never breaks