### PR TITLE
Split APKs per abi to publish in GH release

### DIFF
--- a/.github/workflows/flutter_release.yml
+++ b/.github/workflows/flutter_release.yml
@@ -92,7 +92,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: |
-            ${{vars.ANDROID_BUILD_PATH }/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V7A}}
+            ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V7A}}
             ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V8A}}
             ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_x86_64}}
 

--- a/.github/workflows/flutter_release.yml
+++ b/.github/workflows/flutter_release.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LINUX_ZIP: Vernet-${{github.ref_name}}-linux.zip
-      ANDROID_APK_ARM_V7A: app-armeabi-v7a-dev-release.apk
-      ANDROID_APK_ARM_V8A: app-arm64-v8a-dev-release.apk
-      ANDROID_APK_x86_64: app-x86_64-dev-release.apk
+      ANDROID_APK_ARM_V7A: app-armeabi-v7a-dev-debug.apk
+      ANDROID_APK_ARM_V8A: app-arm64-v8a-dev-debug.apk
+      ANDROID_APK_x86_64: app-x86_64-dev-debug.apk
 
     steps:
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
       - name: Build Android App and Linux Bundle
         # Use signing keys for release instead of debug
         run: |
-          flutter build apk --split-per-abi --flavor dev
+          flutter build apk --debug --split-per-abi --flavor dev
           flutter build linux --release
 
       - name: Rename ANDROID APKs

--- a/.github/workflows/flutter_release.yml
+++ b/.github/workflows/flutter_release.yml
@@ -16,8 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LINUX_ZIP: Vernet-${{github.ref_name}}-linux.zip
-      ANDROID_APK: app-store-debug.apk
-      ANDROID_APK_PUB: Vernet-${{github.ref_name}}-Android.apk
+      ANDROID_APK_ARM_V7A: app-armeabi-v7a-dev-release.apk
+      ANDROID_APK_ARM_V8A: app-arm64-v8a-dev-release.apk
+      ANDROID_APK_x86_64: app-x86_64-dev-release.apk
 
     steps:
       - name: Checkout
@@ -68,11 +69,14 @@ jobs:
       - name: Build Android App and Linux Bundle
         # Use signing keys for release instead of debug
         run: |
-          flutter build apk --debug --flavor store 
+          flutter build apk --split-per-abi --flavor dev
           flutter build linux --release
 
-      - name: Rename Android APK
-        run: mv ${{ vars.ANDROID_BUILD_PATH }}/${{ env.ANDROID_APK }} ${{ vars.ANDROID_BUILD_PATH }}/${{ env.ANDROID_APK_PUB }}
+      - name: Rename ANDROID APKs
+        run: |
+          mv ${{vars.ANDROID_BUILD_PATH}}/${{env.ANDROID_APK_ARM_V7A}} ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V7A}}
+          mv ${{vars.ANDROID_BUILD_PATH}}/${{env.ANDROID_APK_ARM_V8A}} ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V8A}}
+          mv ${{vars.ANDROID_BUILD_PATH}}/${{env.ANDROID_APK_x86_64}} ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_x86_64}}
 
       - name: Linux Archive
         uses: thedoctor0/zip-release@master
@@ -87,7 +91,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ${{ vars.ANDROID_BUILD_PATH }}/${{ env.ANDROID_APK_PUB }}
+          files: |
+            ${{vars.ANDROID_BUILD_PATH }/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V7A}}
+            ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_ARM_V8A}}
+            ${{vars.ANDROID_BUILD_PATH}}/Vernet-${{github.ref_name}}-${{env.ANDROID_APK_x86_64}}
 
       - name: Publish Linux Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -3,6 +3,8 @@ name: Flutter Test
 on:
   pull_request:
     branches: [ "main", "dev" ]
+     paths-ignore:
+      - '.github/**'
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -3,8 +3,6 @@ name: Flutter Test
 on:
   pull_request:
     branches: [ "main", "dev" ]
-    paths-ignore:
-      - '.github/**'
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -3,7 +3,7 @@ name: Flutter Test
 on:
   pull_request:
     branches: [ "main", "dev" ]
-     paths-ignore:
+    paths-ignore:
       - '.github/**'
   workflow_dispatch:
   workflow_call:


### PR DESCRIPTION
Splitted apk into all these artifacts, so that fat apk need not be published.

Built build/app/outputs/flutter-apk/app-armeabi-v7a-dev-release.apk
Built build/app/outputs/flutter-apk/app-arm64-v8a-dev-release.apk
Built build/app/outputs/flutter-apk/app-x86_64-dev-release.apk