### PR TITLE
Run default scan (Top) if device is passed

### DIFF
--- a/lib/pages/host_scan_page/widgets/host_scan_widget.dart
+++ b/lib/pages/host_scan_page/widgets/host_scan_widget.dart
@@ -76,6 +76,7 @@ class HostScanWidget extends StatelessWidget {
                               MaterialPageRoute(
                                 builder: (context) => PortScanPage(
                                   target: host.internetAddress.address,
+                                  runDefaultScan: true,
                                 ),
                               ),
                             );

--- a/lib/pages/network_troubleshoot/port_scan_page.dart
+++ b/lib/pages/network_troubleshoot/port_scan_page.dart
@@ -10,9 +10,10 @@ import 'package:vernet/ui/custom_tile.dart';
 import 'package:vernet/ui/popular_chip.dart';
 
 class PortScanPage extends StatefulWidget {
-  const PortScanPage({this.target = ''});
+  const PortScanPage({this.target = '', this.runDefaultScan = false});
 
   final String target;
+  final bool runDefaultScan;
 
   @override
   _PortScanPageState createState() => _PortScanPageState();
@@ -114,6 +115,9 @@ class _PortScanPageState extends State<PortScanPage>
     super.initState();
     _tabController = TabController(length: _tabs.length, vsync: this);
     _targetIPEditingController.text = widget.target;
+    if (widget.runDefaultScan) {
+      Future.delayed(Durations.short2, _startScanning);
+    }
   }
 
   ScanType? _type = ScanType.top;


### PR DESCRIPTION
Now navigating from host scan, Port scan page will automatically run `Top` port scan.